### PR TITLE
Add PokePCFollowers and Pokemon Gold compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,21 @@
 
 Gives every Gen 1 Pokemon its own unique party/menu icon instead of
 the vanilla shared body-type icons (BALL, BIRD, BUG, FAIRY, GRASS,
-HELIX, MON, QUADRUPED, SNAKE, WATER). As for 1.4.0, also includes
-Gen 2 Pokemon, for compatibility with certain mods.
+HELIX, MON, QUADRUPED, SNAKE, WATER). Version 1.5.0 supports all 251
+Gen 1 and Gen 2 Pokemon on Red, Blue, Yellow, and Gold.
 
 ## Installation
 
 Simply drag-and-drop the .zip file into the mods section of the gen1recomp launcher. Restart the game for color pallete changes to be effective.
+
+### PokePCFollowers compatibility
+
+Unique Menu Icons 1.5.0 and PokePCFollowers 0.8.1 can be enabled together.
+Unique Menu Icons owns the party-menu icons and their color mode; PokePC keeps
+the overworld follower and its `FOLLOWER` party action. The optional dependency
+loads this mod after PokePC so the icon assignment is deterministic. Do not use
+Unique Menu Icons 1.4.0 for this combination: that release declares PokePC
+incompatible in its manifest.
 
 ## Color modes
 
@@ -40,12 +49,12 @@ three tones a real icon OBJ can actually display.
 
 ### Why three separate art sets instead of one
 
-The menu icon column always renders through a single shared,
-hardcoded palette ("MEWMON", `src/ui/PartyMenu.lua`), no matter which
-species is shown — and that same palette also colors the title screen
-and Oak's intro speech. Earlier versions of this mod got Gen 2 colors
-by overriding that palette directly, which meant the title screen and
-intro turned red too as a side effect.
+On Gen 1, the menu icon column renders through a single shared, hardcoded
+palette ("MEWMON", `src/ui/PartyMenu.lua`), no matter which species is shown
+— and that same palette also colors the title screen and Oak's intro speech.
+Gold likewise applies its party-menu OBJ palette to every icon. Earlier
+versions of this mod got Gen 2 colors by overriding the Gen 1 palette directly,
+which meant the title screen and intro turned red too as a side effect.
 
 **GBC RED** and **UNIQUE COLORS** avoid that entirely by using the
 same **trueColor zone** mechanism the engine's own trueColor
@@ -62,9 +71,9 @@ display palette is active. Since `R.icons` (the mod content registry
 for menu icons) has no `trueColor` field to opt into this directly,
 the mod wraps `PartyMenu:draw()` — a real table method, so it's safely
 monkey-patchable, unlike the private `drawIcon()` function it calls
-internally — and, right after the original draw runs, marks a
-trueColor rect for each party slot's icon at its known screen
-position (`x = 8`, `y = PartyMenu.entryY(i) = (i-1)*16`, size 16x16).
+internally — and, right after the original draw runs, marks a 16x16 trueColor
+rect at each icon's generation-specific position. On Gold this follows both
+the selected icon's horizontal shift and its two-pixel bounce.
 
 **ORIGINAL never installs this patch at all** — it's the plain,
 fully-vanilla-behaved option for players who don't want any palette
@@ -84,28 +93,28 @@ color.
 
 - `manifest.json` — mod manifest (api 2).
 - `main.lua` — defines the `ICON COLOR MODE` option, registers a
-  unique icon for each of the 151 Gen 1 species from the selected
+  unique icon for each of the 251 Gen 1 and Gen 2 species from the selected
   mode's folder, and (for GBC RED / UNIQUE COLORS only) patches
   `PartyMenu:draw()` to mark each icon as a trueColor zone.
-- `assets/icons_original/*.png` — 3-tone grayscale art (highlight + fill + outline).
-- `assets/icons_gbc_red/*.png` — Gen 2 red/white/black duotone, literal RGB.
-- `assets/icons_color/*.png` — full, real per-species color, literal RGB.
+- `assets/icon_original/*.png` — 3-tone grayscale art (highlight + fill + outline).
+- `assets/icon_gbc_red/*.png` — Gen 2 red/white/black duotone, literal RGB.
+- `assets/icon_color/*.png` — full, real per-species color, literal RGB.
 
-All three are 151 icons each, 16x32 (two 16x16 frames stacked for the
+All three are 251 icons each, 16x32 (two 16x16 frames stacked for the
 menu's bounce animation).
 
 ## Swapping in different art
 
 Overwrite the species' file inside whichever mode's folder you're
-using. For `icons_original`, keep to the 3 tones a real icon OBJ can
+using. For `icon_original`, keep to the 3 tones a real icon OBJ can
 show: highlight pixels at `255`, fill pixels at `170`, and outline
 pixels at `0` (see the note above on why) -- so the normal palette
-recolor keeps working; `icons_gbc_red` and `icons_color` can use
+recolor keeps working; `icon_gbc_red` and `icon_color` can use
 literal color freely, since they render through the trueColor patch.
 
 ```
-assets/icons_original/PIKACHU.png
-assets/icons_color/CHARIZARD.png
+assets/icon_original/PIKACHU.png
+assets/icon_color/CHARIZARD.png
 ```
 
 No need to touch `main.lua` — the paths are already registered. If a

--- a/main.lua
+++ b/main.lua
@@ -3,7 +3,7 @@
 -- Icon art: MiniDex sprites by Chamber, Solo0993, Blue Emerald, Lake,
 -- Neslug and Pikachu25. All credit for the original art goes to them.
 --
--- Gives every Gen 1 species its own unique party/menu icon instead of
+-- Gives every Gen 1 and Gen 2 species its own unique party/menu icon instead of
 -- sharing the vanilla body-type icons (BALL, BIRD, BUG, FAIRY, GRASS,
 -- HELIX, MON, QUADRUPED, SNAKE, WATER).
 --
@@ -289,9 +289,9 @@ local SPECIES = {
 }
 
 local MODES = {
-  { id = "original",      label = "ORIGINAL (no palette changes)",     folder = "assets/icons_original" },
-  { id = "gbc_red",        label = "GBC RED (Gen 2 style, all mons)",   folder = "assets/icons_gbc_red" },
-  { id = "unique_colors",  label = "UNIQUE COLORS (real per-species)",  folder = "assets/icons_color" },
+  { id = "original",      label = "ORIGINAL (no palette changes)",     folder = "assets/icon_original" },
+  { id = "gbc_red",       label = "GBC RED (Gen 2 style, all mons)",   folder = "assets/icon_gbc_red" },
+  { id = "unique_colors", label = "UNIQUE COLORS (real per-species)", folder = "assets/icon_color" },
 }
 local DEFAULT_MODE = "original"
 
@@ -303,6 +303,14 @@ local function findMode(id)
 end
 
 return function(mod)
+  local GameVersion = require("src.core.GameVersion")
+  local isGen2 = GameVersion.generation() == 2
+
+  -- Compatibility capability consumed by PokePCFollowers 0.8.1+.  The
+  -- optional dependency keeps this mod later in the load order, so its icon
+  -- assignments win while PokePC retains ownership of overworld followers.
+  if mod.exports then mod.exports.ownsPartyIcons = true end
+
   local choices = {}
   for _, m in ipairs(MODES) do
     choices[#choices + 1] = { m.label, m.id }
@@ -323,8 +331,17 @@ return function(mod)
 
   local registered, skipped = 0, 0
   local hasArt = {}
+  local icons = mod.content.icons
 
-  for _, name in ipairs(SPECIES) do
+  local function replaceOrRegister(id, value)
+    if icons:get(id) ~= nil then
+      icons:override(id, value)
+    else
+      icons:register(id, value)
+    end
+  end
+
+  for dex, name in ipairs(SPECIES) do
     local iconPath = mode.folder .. "/" .. name .. ".png"
 
     -- Fall back to the default mode's art if the selected mode is
@@ -334,16 +351,26 @@ return function(mod)
     end
 
     if mod:read(iconPath) then
-      -- Always override, never register: another mod (PokePCFollowers,
-      -- Kanto Reforged, etc.) may register/patch this same species id.
-      -- register() would collide with whatever another mod queues for
-      -- this id at merge time -- see CHIKORITA/Kanto Reforged and
-      -- BULBASAUR/PokePCFollowers reports. override() has no existence
-      -- check, so it's safe unconditionally and always wins the merge.
-      mod.content.icons:override(name, {
-        image = mod.assets:path(iconPath),
-        frames = 2,
-      })
+      if isGen2 then
+        -- Gold separates icon sheets from per-species assignments.  Give each
+        -- species its own two-frame sheet, then point the species at that id.
+        local iconId = "ICON_UNIQUE_" .. string.format("%03d", dex)
+        replaceOrRegister(iconId, {
+          id = iconId,
+          image = mod.assets:path(iconPath),
+          width = 16,
+          height = 32,
+          frames = 2,
+        })
+        icons:override(name, iconId)
+      else
+        -- The optional dependency places us after other icon providers, and
+        -- override() makes this assignment the final Gen 1 party icon.
+        icons:override(name, {
+          image = mod.assets:path(iconPath),
+          frames = 2,
+        })
+      end
       registered = registered + 1
       hasArt[name] = true
     else
@@ -352,37 +379,58 @@ return function(mod)
   end
 
   -- Only modes 2 and 3 need the trueColor patch. Mode 1 relies on the
-  -- normal palette-driven recolor, exactly like vanilla icons, and
-  -- deliberately never touches PartyMenu or PaletteFX at all.
+  -- normal palette-driven recolor, exactly like vanilla icons.
   local patchOk, patchErr = true, nil
   if mode.id ~= "original" then
     patchOk, patchErr = pcall(function()
       local PartyMenu = require("src.ui.PartyMenu")
       local PaletteFX = require("src.render.PaletteFX")
+      local state = PartyMenu.__uniqueMenuIconsPartyMenu
+      if not state then
+        state = { originalDraw = PartyMenu.draw }
+        state.wrapperDraw = function(self, ...)
+          local result = state.originalDraw and state.originalDraw(self, ...)
+          if state.afterDraw then pcall(state.afterDraw, self) end
+          return result
+        end
+        PartyMenu.draw = state.wrapperDraw
+        PartyMenu.__uniqueMenuIconsPartyMenu = state
+      end
 
-      if PartyMenu._uniqueMenuIconsTrueColorWrapped then return end
-
-      local origDraw = PartyMenu.draw
-      function PartyMenu:draw(...)
-        origDraw(self, ...)
-
+      -- Refresh the callback rather than adding another wrapper on reload.
+      state.afterDraw = function(self)
         local party = self.party or (self.game and self.game.save and self.game.save.party)
         if type(party) ~= "table" then return end
 
         for i, mon in ipairs(party) do
           if mon and hasArt[mon.species] then
-            local y = PartyMenu.entryY(i)
-            PaletteFX.markTrueColor(8, y, 16, 16)
+            local x, y
+            if isGen2 then
+              x = i == self.index and 8 or 0
+              local clock = tonumber(self.clock) or 0
+              local bob = i == self.index and
+                ((math.floor(clock / 16) % 2 == 1) and -2 or 0) or 0
+              y = 4 + (i - 1) * 16 + bob
+            else
+              x = 8
+              y = PartyMenu.entryY(i)
+            end
+            PaletteFX.markTrueColor(x, y, 16, 16)
           end
         end
       end
-
-      PartyMenu._uniqueMenuIconsTrueColorWrapped = true
     end)
 
     if not patchOk then
       mod.log:warn("unique_menu_icons: trueColor icon patch failed: %s", tostring(patchErr))
     end
+  else
+    -- A previous hot-loaded colored mode may have installed the stable wrapper.
+    -- Disable only its color callback; leaving the wrapper in place avoids
+    -- disturbing wrappers installed by other mods around it.
+    local okParty, PartyMenu = pcall(require, "src.ui.PartyMenu")
+    local state = okParty and PartyMenu.__uniqueMenuIconsPartyMenu
+    if state then state.afterDraw = nil end
   end
 
   mod.log:info(

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
   "id": "unique_menu_icons",
   "name": "Unique Menu Icons",
-  "version": "1.4.0",
-  "description": "Gives every Gen 1 and Gen 2 (Johto) Pokemon its own unique party/menu icon instead of the vanilla shared body-type icons (QUADRUPED, BIRD, SNAKE, etc). Pick a color mode in Options > Mods: ORIGINAL, GBC RED, or UNIQUE COLORS. Modes 2 and 3 use a trueColor screen-zone patch instead of overriding any shared palette, so the title screen and Oak's intro are never affected, however they may impact some other mods such as the DexNav or the PC Grid UI. Icon registration now always uses override() instead of register(), so it can no longer crash the mod manager when another mod (PokePCFollowers, Kanto Reforged, Kanto Ascendant, Crystal 251, etc.) also registers/patches the same species icon id -- previously this hit a 'icons already registered' error. If PokePCFollowers (PokePCFollowers_VoxelMerge), Kanto Reforged (Kanto-Reforged), Kanto Ascendant (trainer_rematch), or Crystal 251 (CRYSTAL_251) are also enabled, this mod loads after them and its icons win in the party menu. Note: this only prevents US from crashing -- a mod that still uses register() for the same icon id can still fail to load itself when this mod is active; see this mod's README/issues for details. Icon art: MiniDex sprites by Chamber, Solo0993, Blue Emerald, Lake, Neslug and Pikachu25.",
+  "version": "1.5.0",
+  "description": "Unique party/menu icons for all 251 Gen 1 and Gen 2 Pokemon, with ORIGINAL, GBC RED, and UNIQUE COLORS modes. Supports Red, Blue, Yellow, and Gold. When PokePCFollowers is enabled, this mod loads after it and owns the party-menu icons while PokePC continues to provide overworld followers.",
   "entry": "main.lua",
   "github": "menyas/unique-menu-icons",
+  "games": ["gen1", "gen2"],
   "permissions": ["engine_internals"],
   "optional_dependencies": ["PokePCFollowers_VoxelMerge", "Kanto-Reforged", "trainer_rematch", "CRYSTAL_251"],
-  "incompatible": ["PokePCFollowers_VoxelMerge"],
   "api": 2
 }
 


### PR DESCRIPTION
## What changed

- removes the hard incompatibility with `PokePCFollowers_VoxelMerge` while keeping the optional dependency so Unique Menu Icons loads last and wins party-menu icon assignments
- publishes `mod.exports.ownsPartyIcons = true` for coordinated ownership with PokePCFollowers 0.8.1+
- adds Red/Blue/Yellow and Pokemon Gold support through generation-specific icon registration
- registers `ICON_UNIQUE_*` two-frame sheets plus species assignments on Gold
- keeps ORIGINAL palette-driven and applies trueColor only to GBC RED / UNIQUE COLORS
- tracks Gold's selected-icon x shift and two-pixel bob when marking trueColor rectangles
- makes the PartyMenu wrapper stable across hot reloads
- fixes the repository asset paths (`assets/icon_*`) and updates the README

## Root cause

Release 1.4.0 listed PokePCFollowers as both an optional dependency and an incompatible mod, so the loader disabled Unique Menu Icons before its entrypoint ran. Removing that declaration exposes a second visual conflict: PokePC also marked party rows trueColor, which bypassed this mod's ORIGINAL palette mode. PokePCFollowers 0.8.1 now yields party-icon color ownership when this mod is active.

PokePC compatibility release: https://github.com/mfrtechconsult/PokePCFollowers/releases/tag/v0.8.1

## Validation

- `modkit validate --strict --base fixture`: both mods pass
- `modkit gen2check --strict`: both mods load on Gen 2
- headless integration matrix: Gen 1 + Gold x ORIGINAL / GBC RED / UNIQUE COLORS, all green
- all 251 assets registered; Charmander and Totodile assignments verified on both generations
- repeated-load checks confirm the PartyMenu wrappers do not stack
- real Pokemon Gold smoke: both mods loaded with no manager errors; Unique Menu Icons owned party icons while PokePC kept Totodile's overworld follower and the FOLLOWING action

This proposes version 1.5.0 because native Pokemon Gold support is a new feature in addition to the compatibility fix.